### PR TITLE
Add meson.build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .vscode/
 hyprsplit.so
 result
+build
+compile_commands.json
+.cache

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
         version = "0.1";
         src = ./.;
 
-        nativeBuildInputs = with pkgs; [pkg-config];
+        nativeBuildInputs = with pkgs; [pkg-config meson ninja];
         buildInputs = with pkgs;
           [
             hyprland.packages.${system}.hyprland.dev
@@ -28,15 +28,6 @@
             libdrm
           ]
           ++ hyprland.packages.${system}.hyprland.buildInputs;
-
-        installPhase = ''
-          runHook preInstall
-
-          mkdir -p $out/lib
-          mv hyprsplit.so $out/lib/libhyprsplit.so
-
-          runHook postInstall
-        '';
 
         meta = with pkgs.lib; {
           homepage = "https://github.com/shezdy/hyprsplit";
@@ -52,7 +43,11 @@
     devShells = eachSystem (system: let
       pkgs = pkgsFor.${system};
     in {
-      default = pkgs.gcc13Stdenv.mkShell {
+      default = pkgs.mkShell.override {stdenv = pkgs.gcc13Stdenv;} {
+        shellHook = ''
+          meson setup build --reconfigure
+          cp ./build/compile_commands.json ./compile_commands.json
+        '';
         name = "hyprsplit";
         inputsFrom = [self.packages.${system}.hyprsplit];
       };

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,22 @@
+project('hyprsplit', 'cpp',
+  version: '0.1',
+  default_options: ['buildtype=release', 'cpp_std=c++23', 'warning_level=1'],
+)
+
+add_project_arguments(
+  [
+    '-DWLR_USE_UNSTABLE'
+  ],
+  language: 'cpp')
+
+globber = run_command('find', '.', '-name', '*.cpp', check: true)
+src = globber.stdout().strip().split('\n')
+
+shared_module(meson.project_name(), src,
+  dependencies: [
+    dependency('hyprland'),
+    dependency('pixman-1'),
+    dependency('libdrm'),
+  ],
+  install: true,
+)


### PR DESCRIPTION
Following up on the PR yesterday to add meson.build, to match how other hyprland plugins are built

I'd also propose removing Makefile, but it doesn't matter that much

Also updated the flake.nix to generate compile_commands.json when using a devshell, makes working on the code easier if something like neovim is being used wher it doesn't automatically generate it

Tested on my dots