### PR TITLE
Don't use iterator to loop through workspaces

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,7 +100,9 @@ void ensureGoodWorkspaces() {
             m->changeWorkspace(ws, false, true, true);
         }
 
-        for (auto& ws : g_pCompositor->m_vWorkspaces) {
+        const auto WSSIZE = g_pCompositor->m_vWorkspaces.size();
+        for (size_t i = 0; i < WSSIZE; i++) {
+            const auto& ws = g_pCompositor->m_vWorkspaces[i];
             if (!valid(ws))
                 continue;
 


### PR DESCRIPTION
moveWorkspaceToMonitor can potentially mutate the workspaces vector, which is bad since this is called inside a loop using an iterator. Convert to a boring for loop with index.

