### PR TITLE
Commit Pins for Nix Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,13 +20,14 @@
       rawCommitPins
     );
     srcRev = "${commitPins.${hyprland.rev} or "git"}";
+    srcRevShort = builtins.substring 0 7 srcRev;
   in {
     packages = eachSystem (system: let
       pkgs = pkgsFor.${system};
     in rec {
       hyprsplit = pkgs.stdenv.mkDerivation {
         pname = "hyprsplit";
-        version = "0.1";
+        version = "flakeRev=${self.shortRev or "dirty"}_srcRev=${srcRevShort}";
         src =
           if (commitPins ? ${hyprland.rev}) && (self ? rev)
           then


### PR DESCRIPTION
This adds commit pinning boilerplate for nix flake, to share commit pins with hyprpm.
 
Behaviors are roughly described in https://github.com/dawsers/hyprscroller/pull/47