### PR TITLE
Fix build on NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
             })
           else ./.;
 
-        nativeBuildInputs = with pkgs; [pkg-config meson ninja];
+        nativeBuildInputs = with pkgs; [pkg-config meson ninja gcc14];
         buildInputs = with pkgs;
           [
             hyprland.packages.${system}.hyprland.dev
@@ -60,7 +60,7 @@
     devShells = eachSystem (system: let
       pkgs = pkgsFor.${system};
     in {
-      default = pkgs.mkShell.override {stdenv = pkgs.gcc13Stdenv;} {
+      default = pkgs.mkShell.override {stdenv = pkgs.gcc14Stdenv;} {
         shellHook = ''
           meson setup build --reconfigure
           cp ./build/compile_commands.json ./compile_commands.json


### PR DESCRIPTION
Hyprlang seems to have updated to use gcc14 in some way, and this causes compile errors in other tools. This moves hyprsplit to gcc14 to fix the compile errors.

See https://github.com/hyprwm/hyprlang/issues/60

I'm probably not doing this in the most idiomatic/nixlike way, feel free to fix