### PR TITLE
Added HYPRSPLIT environment variable during configuration parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,10 @@ bind = SUPER SHIFT, 6, split:movetoworkspacesilent, 6
 
 bind = SUPER, D, split:swapactiveworkspaces, current +1
 bind = SUPER, G, split:grabroguewindows
+
+# Only bind if hyprsplit plugin is loaded, requires Hyprland >= v0.51.0
+# hyprlang if HYPRSPLIT
+bind = SUPER CONTROL, 1, split:movetoworkspace, 1
+# hyprlang endif
+
 ```

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -455,6 +455,22 @@ void onMonitorRemoved(PHLMONITOR pMonitor) {
     }
 }
 
+static std::vector<const char*> HYPRSPLIT_VERSION_VARS = {
+    "HYPRSPLIT",
+};
+
+static void exportHyprSplitVersionEnv() {
+    for (const auto& v : HYPRSPLIT_VERSION_VARS) {
+        setenv(v, "1", 1);
+    }
+}
+
+static void clearHyprSplitVersionEnv() {
+    for (const auto& v : HYPRSPLIT_VERSION_VARS) {
+        unsetenv(v);
+    }
+}
+
 // other plugins can use this to convert a regular hyprland workspace string the correct hyprsplit one
 APICALL EXPORT std::string hyprsplitGetWorkspace(const std::string& workspace) {
     return getWorkspaceOnCurrentMonitor(workspace);
@@ -496,6 +512,10 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
         HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorRemoved", [&](void* self, SCallbackInfo& info, std::any data) { onMonitorRemoved(std::any_cast<PHLMONITOR>(data)); });
     static auto configReloadedHook =
         HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded", [&](void* self, SCallbackInfo& info, std::any data) { ensureGoodWorkspaces(); });
+    static auto preConfigReloadSetEnvHook =
+        HyprlandAPI::registerCallbackDynamic(PHANDLE, "preConfigReload", [&](void* self, SCallbackInfo& info, std::any data) { exportHyprSplitVersionEnv(); });
+    static auto configReloadedRemoveEnvHook =
+        HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded", [&](void* self, SCallbackInfo& info, std::any data) { clearHyprSplitVersionEnv(); });
 
     HyprlandAPI::reloadConfig();
 


### PR DESCRIPTION
Sets `HYPRSPLIT` environment variable before parsing hyprland config and unsets the variable after config is reloaded.
Variable can be used in hyprlands config with `# hyprlang if HYPRSPLIT` conditional.
My usecase for this is enabling use of the same keybinds when hyprsplit is loaded and not loaded, example below.

```
# hyprlang if HYPRSPLIT
bind = SUPER, 1, split:workspace, 1
# hyprlang endif

# hyprlang if !HYPRSPLIT
bind = SUPER, 1, workspace, 1
# hyprlang endif
```
