### PR TITLE
Fix persistent workspaces being destroyed on monitor disconnect

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,7 +157,7 @@ void ensureGoodWorkspaces() {
                 wsRule.workspaceId             = i;
                 wsRule.workspaceName           = wsRule.workspaceString;
                 wsRule.isPersistent            = true;
-                wsRule.monitor                 = std::to_string(m->m_id);
+                wsRule.monitor                 = m->m_name;
                 wsRule.layoutopts["hyprsplit"] = "1";
 
                 const auto IT = std::ranges::find_if(g_pConfigManager->m_workspaceRules,


### PR DESCRIPTION

Problem
  When disconnecting a monitor (e.g., closing laptop lid), persistent workspaces on other monitors were being destroyed with errors:
  Error in getMonitorFromString: invalid arg 1
  Destroying workspace ID 17, 18, 19, 20

  ### Root Cause
  Workspace rules stored monitor **numeric ID** (`"0"`, `"1"`, `"2"`, `"3"`) instead of monitor **name** (`"eDP-1"`, `"DP-5"`, etc.).

  When Hyprland's `getMonitorFromString()` tried to look up monitors by these numeric IDs, it failed and destroyed the associated workspaces.