### PR TITLE
fix(monitor_priority): compare the iterated monitor in the unmapped scan

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -56,8 +56,8 @@ function MonitorRange:new(monitor)
                     local mapped = false
                     for _, monitor_selector in ipairs(hyprsplit.monitor_priority_list) do
                         if
-                            monitor.name == monitor_selector
-                            or monitor.description == monitor_selector
+                            m.name == monitor_selector
+                            or m.description == monitor_selector
                         then
                             mapped = true
                             break


### PR DESCRIPTION
### Problem

With `monitor_priority` in use, monitors **not** listed get a workspace base
that is too high, so their workspace range is wrong.

My setup — one physical monitor and one headless output created at runtime:

```lua
local hs = require("hyprsplit")
hs.config({ num_workspaces = 10 })
hs.monitor_priority({ "DP-1" })
```

Expected `DP-1` → 1-10, `HEADLESS-1` → 11-20.
Actual `HEADLESS-1` → **21-30**.

### Cause

In `MonitorRange:new`, the scan that collects unmapped monitors compares the
**outer** `monitor` (the one whose range is being computed) instead of `m`,
the monitor currently being iterated:

```lua
for _, m in ipairs(hl.get_monitors()) do
    ...
    for _, monitor_selector in ipairs(hyprsplit.monitor_priority_list) do
        if
            monitor.name == monitor_selector          -- always the same monitor
            or monitor.description == monitor_selector
        then
```

While computing the range for an unlisted monitor, that condition is false for
every `m`, so **no** monitor is ever marked as mapped. Monitors already present
in `monitor_priority_list` end up in `unmappedMonitors` as well, which shifts
the index of the genuinely unmapped ones by the size of the priority list.

For the example above `unmappedMonitors` becomes `{DP-1, HEADLESS-1}`, giving
`HEADLESS-1` index 1, hence `base = 1 + #monitor_priority_list = 2` → 21-30.

### Fix

Compare the iterated monitor.

### Verification

Extracting the function's logic and running it standalone against two mock
monitors, `{"DP-1"}` as the priority list:

```
before: DP-1=1-10  HEADLESS-1=21-30
after:  DP-1=1-10  HEADLESS-1=11-20
```

Confirmed on Hyprland 0.56.2: after the change the headless output is assigned
11-20 and `hs.dsp.focus({ workspace = 1 })` on it lands on workspace 11.

### Unrelated note

If `base` is never assigned it stays `-1`, which yields `min = -9`, `max = 0`.
The identity check `if monitor == m` a few lines below relies on the two values
being the same object. That held in my testing, so I left it alone — but if
`monitor` can ever arrive from a different source than `hl.get_monitors()`,
a name comparison plus a guard on `base == -1` might be worth adding.
